### PR TITLE
fix shared gpu memory increase, remove 2 buffers, use fixed share handle

### DIFF
--- a/windows/d3d11_output.h
+++ b/windows/d3d11_output.h
@@ -34,11 +34,10 @@ private:
 private:
   flutter::TextureRegistrar *texture_registrar_ = nullptr;
   ComPtr<ID3D11Texture2D> tex_ = nullptr;
-  ComPtr<ID3D11Texture2D> tex_buffers_[2] = {nullptr, nullptr};
-  std::unique_ptr<FlutterDesktopGpuSurfaceDescriptor> surface_desc_[2] = {
-      nullptr, nullptr};
-  int free_ = 0;
-  int busy_ = 0;
+  ComPtr<ID3D11Texture2D> tex_buffers_ = nullptr;
+  ComPtr<ID3D11Device> dev_ = nullptr;
+  ComPtr<ID3D11DeviceContext> ctx_ = nullptr;
+  std::unique_ptr<FlutterDesktopGpuSurfaceDescriptor> surface_desc_ = nullptr;
   std::mutex mutex_;
   std::unique_ptr<flutter::TextureVariant> variant_ = nullptr;
   int64_t texture_id_ = 0;
@@ -47,6 +46,9 @@ private:
   std::atomic<std::chrono::steady_clock::time_point> fps_time_point_ =
       std::chrono::steady_clock::now();
   bool unusable_ = false;
+  bool desc_ready_ = false;
+  size_t fail_counter_ = 0;
+  bool rendering_ = false;
 };
 
 } // namespace flutter_gpu_texture_renderer


### PR DESCRIPTION
* Using a fixed shared handle prevents an increase in shared GPU memory.
* Changing the codec or resolution causes the D3D11 device to change, resulting in a new handle and an increase in shared GPU memory. https://github.com/flutter/flutter/issues/154716. Even the shared gpu memory reach 1200k Gb after a night, computer runs well.
* In tests, Flutter quickly releases the texture, several us, preventing the copying of texture resources to rendering resources.

https://github.com/user-attachments/assets/4abe5c66-caac-47f2-98e4-17883caf021e

https://github.com/user-attachments/assets/04076a6f-50c3-440e-a840-c4986699b68b


rendering time is the time difference of get/release callbacks, flutter hold the texture between these 2 callbacks.
![2456e7d8f5977612075e94c7ae7f1ea](https://github.com/user-attachments/assets/43dfe5ec-2c08-49a1-b7ee-98450fc6f260)
![7ed447f1799fe85835e4b5ee8b1f27e](https://github.com/user-attachments/assets/2d0a8751-d523-4092-81fa-aa336ae86042)
