### PR TITLE
refact: win, use steady_clock instead of high_resolution_clock

### DIFF
--- a/example/windows/duplication/DDAImpl.cpp
+++ b/example/windows/duplication/DDAImpl.cpp
@@ -268,7 +268,7 @@ void duplicateThread() {
       queryDesc.Query = D3D11_QUERY_EVENT;
       queryDesc.MiscFlags = 0;
       HRC(device->CreateQuery(&queryDesc, query.ReleaseAndGetAddressOf()));
-      auto start = std::chrono::high_resolution_clock::now();
+      auto start = std::chrono::steady_clock::now();
       deviceContext->Begin(query.Get());
       deviceContext->CopyResource(sharedTexture.Get(), texture.Get());
       deviceContext->End(query.Get());
@@ -283,7 +283,7 @@ void duplicateThread() {
         }
       }
       deviceContext->Flush();
-      auto end = std::chrono::high_resolution_clock::now();
+      auto end = std::chrono::steady_clock::now();
       auto elapsed =
           std::chrono::duration_cast<std::chrono::milliseconds>(end - start)
               .count();

--- a/windows/d3d11_output.cpp
+++ b/windows/d3d11_output.cpp
@@ -128,7 +128,7 @@ bool D3D11Output::Present() {
 
 void D3D11Output::SetFPS() {
   this_fps_++;
-  auto now = std::chrono::high_resolution_clock::now();
+  auto now = std::chrono::steady_clock::now();
   auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
                      now - fps_time_point_.load())
                      .count();


### PR DESCRIPTION
Win, use steady_clock instead of high_resolution_clock for better compatibility.